### PR TITLE
Fix conda python 3.5+ build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ boto.cfg
 *.crt
 *.key
 
+python-rtmbot-*/

--- a/basic_install.sh
+++ b/basic_install.sh
@@ -47,15 +47,30 @@ echo "[+] Completed extracted RTM bot"
 echo "[-->] Creating venv in ${RTM_PATH}..."
 
 if command -v pyvenv >/dev/null 2>&1 ; then
-  pyvenv venv
-  source venv/bin/activate
-  echo "[+] Created venv"
 
+  PYTHON_VERSION=`python --version 2>&1 | grep -i continuum`
+  if [[ $PYTHON_VERSION != "" ]]; then
+      echo "[+] Conda installation detected ..."
+      pyvenv venv --without-pip
+      source venv/bin/activate
+
+
+      echo "[-->] Installing PIP in venv..."
+      curl -O https://bootstrap.pypa.io/get-pip.py
+      python get-pip.py
+      echo "[+] PIP Installed"
+  else
+      pyvenv venv
+      source venv/bin/activate
+  fi
+
+  echo "[+] Created venv"
   # Install the dependencies for the rtmbot:
   echo "[-->] Installing rtmbot's dependencies..."
   pip install wheel
   pip install -r requirements.txt
   echo "[+] Completed installing rtmbot dependencies."
+
 
   # Install HubCommander
   echo "[-->] Moving HubCommander to the plugins dir..."

--- a/basic_install.sh
+++ b/basic_install.sh
@@ -54,7 +54,6 @@ if command -v pyvenv >/dev/null 2>&1 ; then
       pyvenv venv --without-pip
       source venv/bin/activate
 
-
       echo "[-->] Installing PIP in venv..."
       curl -O https://bootstrap.pypa.io/get-pip.py
       python get-pip.py


### PR DESCRIPTION
While trying to install the package locally, i faced this issue with Conda.

I use multiple versions of Python within my environment (2.7+), 3.5+ versions are supported by Conda.

Unfortunately Conda's Python version isn't build with PIP, so when we try to call `pyvenv venv` a default argument is added `'ensurepip', '--upgrade'` which causes an error while install.

