### PR TITLE
Depend on python-rtmbot 0.4.0

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@
 - bmanuel
 - retornam
 - invisiblethreat
+- Bryce Boe <bbzbryce@gmail.com>

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,12 @@ RUN \
   apt-get install python3 python3-venv nano -y
 
 # Add all the other stuff to the plugins:
-COPY / /python-rtmbot-${RTM_VERSION}/plugins
+COPY / /python-rtmbot-${RTM_VERSION}/hubcommander
 
 # Install all the things:
 RUN \
   # Rename the rtmbot:
-  mv /python-rtmbot-${RTM_VERSION} /hubcommander && \
+  mv /python-rtmbot-${RTM_VERSION} /rtmbot && \
 
   # Set up the VENV:
   pyvenv /venv && \
@@ -27,15 +27,11 @@ RUN \
   # Install all the deps:
   /bin/bash -c "source /venv/bin/activate && pip install --upgrade pip" && \
   /bin/bash -c "source /venv/bin/activate && pip install wheel" && \
-  /bin/bash -c "source /venv/bin/activate && pip install -r /hubcommander/requirements.txt" && \
-  /bin/bash -c "source /venv/bin/activate && pip install /hubcommander/plugins" && \
+  /bin/bash -c "source /venv/bin/activate && pip install /rtmbot/hubcommander" && \
 
   # The launcher script:
-  mv /hubcommander/plugins/launch_in_docker.sh / && chmod +x /launch_in_docker.sh && \
-  rm /hubcommander/plugins/python-rtmbot-${RTM_VERSION}.tar.gz && \
-
-  # Must remove setup.py to prevent rtmbot from complaining...
-  rm /hubcommander/plugins/setup.py
+  mv /rtmbot/hubcommander/launch_in_docker.sh / && chmod +x /launch_in_docker.sh && \
+  rm /rtmbot/hubcommander/python-rtmbot-${RTM_VERSION}.tar.gz
 
 # DEFINE YOUR ENV VARS FOR SECRETS HERE:
 ENV SLACK_TOKEN="REPLACEMEINCMDLINE" \

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ administrative or `owner` privileges to your GitHub organization members.
 How it works?
 -------------
 HubCommander is based on [slackhq/python-rtmbot](https://github.com/slackhq/python-rtmbot)
-(currently, dependent on release [0.3.0](https://github.com/slackhq/python-rtmbot/releases/tag/0.3.0))
+(currently, dependent on release [0.4.0](https://github.com/slackhq/python-rtmbot/releases/tag/0.4.0))
 
 You simply type `!help`, and the bot will output a list of commands that the bot supports. Typing
 the name of the command, for example: `!CreateRepo`, will output help text on how to execute the command.

--- a/basic_install.sh
+++ b/basic_install.sh
@@ -27,7 +27,7 @@
 # After the files are fetched, the script will attempt to create the python virtual
 # environments and install all the python dependencies (PYTHON 3.5+ IS REQUIRED!)
 
-RTM_VERSION="0.3.0"
+RTM_VERSION="0.4.0"
 RTM_PATH="python-rtmbot-${RTM_VERSION}"
 
 echo "Installing HubCommander and all dependencies..."

--- a/bot_components/slack_comm.py
+++ b/bot_components/slack_comm.py
@@ -8,7 +8,7 @@
 """
 import json
 
-import bot_components
+from .. import bot_components
 
 # A nice color to output
 WORKING_COLOR = "#439FE0"

--- a/bot_components/slack_comm.py
+++ b/bot_components/slack_comm.py
@@ -8,7 +8,7 @@
 """
 import json
 
-from .. import bot_components
+from hubcommander import bot_components
 
 # A nice color to output
 WORKING_COLOR = "#439FE0"

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -36,7 +36,7 @@ if [ $TRAVIS ]; then
     fi
 fi
 
-export RTM_VERSION="0.3.0"
+export RTM_VERSION="0.4.0"
 export RTM_PATH="python-rtmbot-${RTM_VERSION}"
 
 echo "-----------------------------------------"

--- a/command_plugins/enabled_plugins.py
+++ b/command_plugins/enabled_plugins.py
@@ -4,7 +4,7 @@ Use this file to initialize all command plugins.
 The "setup" method will be executed by hubcommander on startup.
 """
 # from command_plugins.travis_ci.plugin import TravisPlugin
-from github.plugin import GitHubPlugin
+from ..github.plugin import GitHubPlugin
 
 GITHUB_PLUGIN = GitHubPlugin()
 

--- a/command_plugins/travis_ci/plugin.py
+++ b/command_plugins/travis_ci/plugin.py
@@ -14,7 +14,7 @@ import requests
 
 from bot_components.bot_classes import BotCommander
 from bot_components.slack_comm import extract_repo_name, send_error, send_info, preformat_args, send_success
-from command_plugins.travis_ci.config import *
+from command_plugins.travis_ci.config import USER_COMMAND_DICT, USER_AGENT
 
 TRAVIS_URLS = {
     "pro": "https://api.travis-ci.com",

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,8 +13,8 @@ The steps below make the following assumptions:
 Basic Installation
 -----------------
 HubCommander is dependent on the [slackhq/python-rtmbot](https://github.com/slackhq/python-rtmbot) 
-release [0.3.0](https://github.com/slackhq/python-rtmbot/releases/tag/0.3.0)). Please review details about the
-python-rtmbot before continuing to install HubCommander.  
+release [0.4.0](https://github.com/slackhq/python-rtmbot/releases/tag/0.4.0)). Please review details about the
+python-rtmbot before continuing to install HubCommander.
 
 Note: Some work will need to be performed to make it compatible with the latest release of the rtmbot, 
 which has some breaking changes (see https://github.com/Netflix/hubcommander/issues/1 for details).
@@ -70,7 +70,7 @@ Out of the box, HubCommander is configured to receive secrets from environment v
 to simplify running HubCommander in Docker. These secrets should not be stored at rest unencrypted.
 
 HubCommander also provides an [AWS KMS](https://aws.amazon.com/kms/) method for extracting an encrypted
-JSON blob that contains the secrets. 
+JSON blob that contains the secrets.
 
 **If your organization utilizes a different mechanism for encrypting credentials, you will need to add code 
 to [`decrypted_creds.py`](https://github.com/Netflix/hubcommander/blob/master/decrypt_creds.py)'s
@@ -78,7 +78,7 @@ to [`decrypted_creds.py`](https://github.com/Netflix/hubcommander/blob/master/de
 
 No matter the encryption mechanism utilized, all secrets are passed into each plugin's `setup()` method, which
 enable the plugins to make authenticated calls to their respective services. You must get the credentials 
-required for plugins to work. 
+required for plugins to work.
 
 1. Contact your Slack administrator to obtain a Slack token that can be used for bots.
 2. If you haven't already, create a GitHub bot account, and invite it to all the organizations that 
@@ -91,14 +91,14 @@ Each plugin in HubCommander typically has a `config.py` file. This is where you 
 configuration that the plugin supports.
 
 For the GitHub plugin, you are required to define a Python `dict` with the organizations that you manage. An example
-of what this `dict` looks like can be found in the sample 
+of what this `dict` looks like can be found in the sample
 [`github/config.py`](https://github.com/Netflix/hubcommander/blob/master/github/config.py) file.
 
 At a minimum, you need to specify the real name of the organization, a list of aliases for the orgs (or an empty list),
 whether the organization can only create public repos (via the `public_only` boolean), as well as 
 a list of `dicts` that define the teams specific to the organization for new repositories will be assigned with. 
 This `dict` consists of 3 parts:
-the `id` of the GitHub org's team (you can get this from the 
+the `id` of the GitHub org's team (you can get this from the
 [`list_teams`](https://developer.github.com/v3/orgs/teams/#list-teams) GitHub API command, along with the 
 permission for that team to have on newly created repos (either `pull`, `push`, or `admin`),
 as well as the actual `name` of the team.
@@ -111,7 +111,7 @@ by HubCommander to perform privileged GitHub tasks.
 You will need to create an [access token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/).
 To do this, you will need to:
 
-1. Log into your GitHub bot user's account. 
+1. Log into your GitHub bot user's account.
 2. Visit [this settings page](https://github.com/settings/tokens) to see the `Personal Access Tokens`
 3. Click `Generate new token`.
 4. Provide a description for this token, such as `HubCommander Slack GitHub Bot API token`.
@@ -129,7 +129,7 @@ To do this, you will need to:
 ### HubCommander Secrets
 
 Once you have your GitHub and Slack Tokens, you are now ready to configure HubCommander (if you wish to make use
-of Travis CI and Duo integration, please refer to the docs for those plugins 
+of Travis CI and Duo integration, please refer to the docs for those plugins
 [here](travis_ci.md) and [here](authentication.md)).
 
 You will need to encrypt the Slack and GitHub credentials. If you make use of AWS, a KMS example is provided 

--- a/github/config.py
+++ b/github/config.py
@@ -1,4 +1,4 @@
-from plugins.hubcommander.auth_plugins.enabled_plugins import AUTH_PLUGINS
+from hubcommander.auth_plugins.enabled_plugins import AUTH_PLUGINS
 
 # Define the organizations that this Bot will examine.
 ORGS = {

--- a/github/config.py
+++ b/github/config.py
@@ -1,4 +1,4 @@
-from auth_plugins.enabled_plugins import AUTH_PLUGINS
+from ..auth_plugins.enabled_plugins import AUTH_PLUGINS
 
 # Define the organizations that this Bot will examine.
 ORGS = {

--- a/github/config.py
+++ b/github/config.py
@@ -1,4 +1,4 @@
-from ..auth_plugins.enabled_plugins import AUTH_PLUGINS
+from plugins.hubcommander.auth_plugins.enabled_plugins import AUTH_PLUGINS
 
 # Define the organizations that this Bot will examine.
 ORGS = {

--- a/github/plugin.py
+++ b/github/plugin.py
@@ -16,7 +16,8 @@ from tabulate import tabulate
 from hubcommander.bot_components.bot_classes import BotCommander
 from hubcommander.bot_components.slack_comm import send_info, send_success, send_error, send_raw, preformat_args, preformat_args_with_spaces, \
     extract_repo_name
-from hubcommander.github.config import *
+from hubcommander.github.config import (GITHUB_URL, GITHUB_VERSION, ORGS,
+                                        USER_COMMAND_DICT)
 
 
 class GitHubPlugin(BotCommander):

--- a/github/plugin.py
+++ b/github/plugin.py
@@ -13,10 +13,10 @@ import requests
 import validators
 from tabulate import tabulate
 
-from ..bot_components.bot_classes import BotCommander
-from ..bot_components.slack_comm import send_info, send_success, send_error, send_raw, preformat_args, preformat_args_with_spaces, \
+from hubcommander.bot_components.bot_classes import BotCommander
+from hubcommander.bot_components.slack_comm import send_info, send_success, send_error, send_raw, preformat_args, preformat_args_with_spaces, \
     extract_repo_name
-from .config import *
+from hubcommander.github.config import *
 
 
 class GitHubPlugin(BotCommander):

--- a/github/plugin.py
+++ b/github/plugin.py
@@ -13,10 +13,10 @@ import requests
 import validators
 from tabulate import tabulate
 
-from bot_components.bot_classes import BotCommander
-from bot_components.slack_comm import send_info, send_success, send_error, send_raw, preformat_args, preformat_args_with_spaces, \
+from ..bot_components.bot_classes import BotCommander
+from ..bot_components.slack_comm import send_info, send_success, send_error, send_raw, preformat_args, preformat_args_with_spaces, \
     extract_repo_name
-from github.config import *
+from .config import *
 
 
 class GitHubPlugin(BotCommander):

--- a/hubcommander.py
+++ b/hubcommander.py
@@ -11,7 +11,7 @@ from rtmbot.core import Plugin
 from hubcommander.auth_plugins.enabled_plugins import AUTH_PLUGINS
 from hubcommander.bot_components.slack_comm import get_user_data, send_error, send_info
 from hubcommander.command_plugins.enabled_plugins import GITHUB_PLUGIN, COMMAND_PLUGINS
-from hubcommander.config import *
+from hubcommander.config import IGNORE_ROOMS, ONLY_LISTEN
 from hubcommander.decrypt_creds import get_credentials
 
 HELP_TEXT = []

--- a/hubcommander.py
+++ b/hubcommander.py
@@ -6,16 +6,13 @@
 
 .. moduleauthor:: Mike Grima <mgrima@netflix.com>
 """
-import slackclient
+from rtmbot.core import Plugin
 
-from auth_plugins.enabled_plugins import AUTH_PLUGINS
-from bot_components.slack_comm import get_user_data, send_error, send_info
-from command_plugins.enabled_plugins import GITHUB_PLUGIN, COMMAND_PLUGINS
-from config import *
-from decrypt_creds import get_credentials
-
-crontable = []
-outputs = []
+from .auth_plugins.enabled_plugins import AUTH_PLUGINS
+from .bot_components.slack_comm import get_user_data, send_error, send_info
+from .command_plugins.enabled_plugins import GITHUB_PLUGIN, COMMAND_PLUGINS
+from .config import *
+from .decrypt_creds import get_credentials
 
 HELP_TEXT = []
 
@@ -35,22 +32,27 @@ COMMANDS = {
 }
 
 
-def process_message(data):
-    """
-    The Slack Bot's only required method -- checks if the message involves this bot.
-    :param data:
-    :return:
-    """
-    if data["channel"] in IGNORE_ROOMS:
-        return
+class HubCommander(Plugin):
+    def __init__(self, **kwargs):
+        super(HubCommander, self).__init__(**kwargs)
+        setup(self.slack_client)
 
-    if len(ONLY_LISTEN) > 0 and data["channel"] not in ONLY_LISTEN:
-        return
+    def process_message(self, data):
+        """
+        The Slack Bot's only required method -- checks if the message involves this bot.
+        :param data:
+        :return:
+        """
+        if data["channel"] in IGNORE_ROOMS:
+            return
 
-    # Only process if it starts with one of our GitHub commands:
-    command_prefix = data["text"].split(" ")[0].lower()
-    if COMMANDS.get(command_prefix):
-        process_the_command(data, command_prefix)
+        if len(ONLY_LISTEN) > 0 and data["channel"] not in ONLY_LISTEN:
+            return
+
+        # Only process if it starts with one of our GitHub commands:
+        command_prefix = data["text"].split(" ")[0].lower()
+        if COMMANDS.get(command_prefix):
+            process_the_command(data, command_prefix)
 
 
 def process_the_command(data, command_prefix):
@@ -75,7 +77,7 @@ def process_the_command(data, command_prefix):
         COMMANDS[command_prefix]["func"](data)
 
 
-def setup():
+def setup(slackclient):
     """
     This is called by the Slack RTM Bot to initialize the plugin.
 
@@ -85,8 +87,8 @@ def setup():
     # Need to open the secrets file:
     secrets = get_credentials()
 
-    import bot_components
-    bot_components.SLACK_CLIENT = slackclient.SlackClient(secrets["SLACK"])
+    from . import bot_components
+    bot_components.SLACK_CLIENT = slackclient
 
     print("[-->] Enabling Auth Plugins")
     for name, plugin in AUTH_PLUGINS.items():

--- a/hubcommander.py
+++ b/hubcommander.py
@@ -8,11 +8,11 @@
 """
 from rtmbot.core import Plugin
 
-from .auth_plugins.enabled_plugins import AUTH_PLUGINS
-from .bot_components.slack_comm import get_user_data, send_error, send_info
-from .command_plugins.enabled_plugins import GITHUB_PLUGIN, COMMAND_PLUGINS
-from .config import *
-from .decrypt_creds import get_credentials
+from hubcommander.auth_plugins.enabled_plugins import AUTH_PLUGINS
+from hubcommander.bot_components.slack_comm import get_user_data, send_error, send_info
+from hubcommander.command_plugins.enabled_plugins import GITHUB_PLUGIN, COMMAND_PLUGINS
+from hubcommander.config import *
+from hubcommander.decrypt_creds import get_credentials
 
 HELP_TEXT = []
 

--- a/launch_in_docker.sh
+++ b/launch_in_docker.sh
@@ -21,11 +21,13 @@
 ################################################################################
 
 # This will build a docker image of HubCommander.
-echo 'DEBUG: False' > /hubcommander/rtmbot.conf
-echo 'SLACK_TOKEN: "'$SLACK_TOKEN'"' >> /hubcommander/rtmbot.conf
+echo 'DEBUG: True' > /rtmbot/rtmbot.conf
+echo 'SLACK_TOKEN: "'$SLACK_TOKEN'"' >> /rtmbot/rtmbot.conf
+echo 'ACTIVE_PLUGINS:' >> /rtmbot/rtmbot.conf
+echo '    - hubcommander.hubcommander.HubCommander' >> /rtmbot/rtmbot.conf
 
 # Launch it!
 export PYTHONIOENCODING="UTF-8"
 source venv/bin/activate
-cd /hubcommander
-python -u rtmbot.py
+cd /rtmbot
+rtmbot

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ install_requires = [
     'boto3>=1.4.3',     # For KMS support
     'duo-client==3.0',
     'tabulate>=0.7.7',
-    'validators>=0.11.1'
+    'validators>=0.11.1',
+    'rtmbot==0.4.0'
 ]
 
 tests_require = [


### PR DESCRIPTION
Resolves #1 

I didn't test the `basic_install.sh` script changes because they didn't actually work in the first place.

The documentation should specify that a `rtmbot.conf` needs to be created that looks something like:

```
DEBUG: True
SLACK_TOKEN: "token"
ACTIVE_PLUGINS:
    - plugins.hubcommander.HubCommander
```