### PR TITLE
New commands for user invitation

### DIFF
--- a/github/plugin.py
+++ b/github/plugin.py
@@ -88,7 +88,7 @@ class GitHubPlugin(BotCommander):
                 "func": self.add_user_to_team_command,
                 "user_data_required": True,
                 "help": "Adds a GitHub user to a specific team inside the organization.",
-                "permitted_permissions": ["maintainer", "member"],
+                "permitted_roles": ["member", "maintainer"],
                 "enabled": True
             }
         }
@@ -376,9 +376,9 @@ class GitHubPlugin(BotCommander):
 
     def add_user_to_team_command(self, data, user_data):
         """
-        Adds a GitHub user to a team with a specified permission.
+        Adds a GitHub user to a team with a specified role.
 
-        Command is as follows: !addusertoteam <user_id> <organization> <team> <permission>
+        Command is as follows: !addusertoteam <user_id> <organization> <team> <role>
         :param data:
         :return:
         """
@@ -387,7 +387,7 @@ class GitHubPlugin(BotCommander):
             parser.add_argument('user_id', type=str)
             parser.add_argument('org', type=str)
             parser.add_argument('team', type=str)
-            parser.add_argument('permission', type=str)
+            parser.add_argument('role', type=str)
 
             args, unknown = parser.parse_known_args(args=preformat_args(data["text"]))
             if len(unknown) > 0:
@@ -399,17 +399,17 @@ class GitHubPlugin(BotCommander):
 
             real_org = self.org_lookup[args["org"]][0]
             team_name = args["team"]
-            team_access = args["permission"]
+            team_access = args["role"]
 
             # Check that the permissions and the org are correct:
-            if team_access not in self.commands["!AddUserToTeam"]["permitted_permissions"]:
-                raise KeyError("Permissions")
+            if team_access not in self.commands["!AddUserToTeam"]["permitted_roles"]:
+                raise KeyError("Roles")
 
         except KeyError as ke:
-            if "Permissions" in str(ke):
+            if "Roles" in str(ke):
                 p_str = " or ".join(["`{perm}`".format(perm=perm)
-                                     for perm in self.commands["!AddUserToTeam"]["permitted_permissions"]])
-                send_error(data["channel"], '@{}: Invalid permission sent in.  Permissions must be {perms}.'
+                                     for perm in self.commands["!AddUserToTeam"]["permitted_roles"]])
+                send_error(data["channel"], '@{}: Invalid roles sent in.  Roles must be {perms}.'
                            .format(user_data["name"], perms=p_str), markdown=True)
             else:
                 send_error(data["channel"], '@{}: Invalid orgname sent in.  Run `!ListOrgs` to see the valid orgs.'
@@ -419,7 +419,7 @@ class GitHubPlugin(BotCommander):
         except SystemExit as _:
             send_info(data["channel"], "@{}: `!AddUserToTeam` usage is:\n```!AddUserToTeam <GitHubUserID> "
                                        "<OrgAlias> <TeamToAddAccessTo> "
-                                       "<PermissionEitherMaintainerOrMember>```"
+                                       "<RoleEitherMemberOrMantainer>```"
                                        "\nNo special characters or spaces in the variables. "
                                        "Run `!ListOrgs` to see the list of GitHub Organizations that I manage. "
                       .format(user_data["name"]), markdown=True)

--- a/github/plugin.py
+++ b/github/plugin.py
@@ -998,7 +998,7 @@ class GitHubPlugin(BotCommander):
 
         data = {"role": role}
 
-        # Add the outside collab to the repo:
+        # Add the GitHub user to the team:
         api_part = 'teams/{}/memberships/{}'.format(team_id, github_id)
         response = requests.put('{}{}'.format(GITHUB_URL, api_part), data=json.dumps(data), headers=headers, timeout=10)
 
@@ -1011,13 +1011,14 @@ class GitHubPlugin(BotCommander):
             'Accept': GITHUB_VERSION
         }
 
-        # Add the outside collab to the repo:
+        # Get all teams inside the organzation:
         api_part = 'orgs/{}/teams'.format(org)
         response = requests.get('{}{}'.format(GITHUB_URL, api_part), headers=headers, timeout=10)
 
         if response.status_code != 200:
             raise ValueError("GitHub Problem: Could not list teams: {}".format(response.status_code))
 
+        # Check if the provided team_name belongs to a team inside the organization:
         for x in response.json():
             if x["slug"] == team_name:
                 return x["id"]

--- a/github/plugin.py
+++ b/github/plugin.py
@@ -1016,7 +1016,7 @@ class GitHubPlugin(BotCommander):
         response = requests.get('{}{}'.format(GITHUB_URL, api_part), headers=headers, timeout=10)
 
         if response.status_code != 200:
-            raise ValueError("GitHub Problem: Could not list teams: {}".format(response.status_code))
+            raise ValueError("GitHub Problem: Could not list teams -- received error code: {}".format(response.status_code))
 
         # Check if the provided team_name belongs to a team inside the organization:
         for x in response.json():

--- a/github/plugin.py
+++ b/github/plugin.py
@@ -376,9 +376,9 @@ class GitHubPlugin(BotCommander):
 
     def add_user_to_org_command(self, data, user_data):
         """
-        Adds an GitHub user to Organization with a specified permission.
+        Adds a GitHub user to Organization with a specified permission.
 
-        Command is as follows: !inviteuser <organization> <permission>
+        Command is as follows: !inviteuser <username> <organization> <permission>
         :param data:
         :return:
         """
@@ -416,7 +416,7 @@ class GitHubPlugin(BotCommander):
 
         except SystemExit as _:
             send_info(data["channel"], "@{}: `!InviteUser` usage is:\n```!InviteUser <GitHubIDOfUser> "
-                                       "<OrgAliasThatContainsTheRepo> "
+                                       "<OrgAlias> "
                                        "<PermissionEitherAdminOrMember>```"
                                        "\nNo special characters or spaces in the variables. "
                                        "Run `!ListOrgs` to see the list of GitHub Organizations that I manage. "

--- a/github/plugin.py
+++ b/github/plugin.py
@@ -83,14 +83,6 @@ class GitHubPlugin(BotCommander):
                 "help": "Delete a GitHub repository.",
                 "enabled": True     # It is HIGHLY recommended you have auth enabled for this!!
             },
-            "!InviteUser": {
-                "command": "!InviteUser",
-                "func": self.add_user_to_org_command,
-                "user_data_required": True,
-                "help": "Adds a GitHub user to a specific GitHub organization.",
-                "permitted_permissions": ["admin", "member"],
-                "enabled": True
-            },
             "!AddUserToTeam": {
                 "command": "!AddUserToTeam",
                 "func": self.add_user_to_team_command,
@@ -380,102 +372,6 @@ class GitHubPlugin(BotCommander):
                      "@{}: The GitHub user: `{}` has been added as an outside collaborator with `{}` "
                      "permissions to {}/{}.".format(user_data["name"], outside_collab_id, repo_access,
                                                     real_org, reponame),
-                     markdown=True)
-
-    def add_user_to_org_command(self, data, user_data):
-        """
-        Adds a GitHub user to Organization with a specified permission.
-
-        Command is as follows: !inviteuser <username> <organization> <permission>
-        :param data:
-        :return:
-        """
-        try:
-            parser = argparse.ArgumentParser()
-            parser.add_argument('user_id', type=str)
-            parser.add_argument('org', type=str)
-            parser.add_argument('permission', type=str)
-
-            args, unknown = parser.parse_known_args(args=preformat_args(data["text"]))
-            if len(unknown) > 0:
-                raise SystemExit()
-
-            args = vars(args)
-
-            user_id = args["user_id"]
-
-            real_org = self.org_lookup[args["org"]][0]
-            org_access = args["permission"]
-
-            # Check that the permissions and the org are correct:
-            if org_access not in self.commands["!InviteUser"]["permitted_permissions"]:
-                raise KeyError("Permissions")
-
-        except KeyError as ke:
-            if "Permissions" in str(ke):
-                p_str = " or ".join(["`{perm}`".format(perm=perm)
-                                     for perm in self.commands["!InviteUser"]["permitted_permissions"]])
-                send_error(data["channel"], '@{}: Invalid permission sent in.  Permissions must be {perms}.'
-                           .format(user_data["name"], perms=p_str), markdown=True)
-            else:
-                send_error(data["channel"], '@{}: Invalid orgname sent in.  Run `!ListOrgs` to see the valid orgs.'
-                           .format(user_data["name"]), markdown=True)
-            return
-
-        except SystemExit as _:
-            send_info(data["channel"], "@{}: `!InviteUser` usage is:\n```!InviteUser <GitHubIDOfUser> "
-                                       "<OrgAlias> "
-                                       "<PermissionEitherAdminOrMember>```"
-                                       "\nNo special characters or spaces in the variables. "
-                                       "Run `!ListOrgs` to see the list of GitHub Organizations that I manage. "
-                      .format(user_data["name"]), markdown=True)
-            return
-
-        # Auth?
-        if self.commands["!InviteUser"].get("auth"):
-            if not self.commands["!InviteUser"]["auth"]["plugin"].authenticate(
-                    data, user_data, **self.commands["!InviteUser"]["auth"]["kwargs"]):
-                return
-
-        # Output that we are doing work:
-        send_info(data["channel"], "@{}: Working, Please wait...".format(user_data["name"]))
-
-        # Check that the GitHub ID is actually real:
-        try:
-            found_user = self.get_github_user(user_id)
-
-            if not found_user:
-                send_error(data["channel"], "@{}: The GitHub user: {} does not exist.".format(user_data["name"],
-                                                                                              user_id))
-                return
-
-        except Exception as e:
-            send_error(data["channel"],
-                       "@{}: A problem was encountered communicating with GitHub to verify the user's GitHub "
-                       "id. Here are the details:\n{}".format(user_data["name"], str(e)))
-            return
-
-        # So: GitHub ID is real - grant access:
-        try:
-            self.add_user_to_org(user_id, real_org, org_access)
-
-        except ValueError as ve:
-            send_error(data["channel"],
-                       "@{}: Problem encountered adding the user to the organization.\n"
-                       "The response code from GitHub was: {}".format(user_data["name"], str(ve)))
-            return
-
-        except Exception as e:
-            send_error(data["channel"],
-                       "@{}: Problem encountered adding the user to the organization.\n"
-                       "Here are the details: {}".format(user_data["name"], str(e)))
-            return
-
-        # Done:
-        send_success(data["channel"],
-                     "@{}: The GitHub user: `{}` has been added to the organization with `{}` "
-                     "permissions to {}/{}.".format(user_data["name"], user_id, org_access,
-                                                    real_org),
                      markdown=True)
 
     def add_user_to_team_command(self, data, user_data):
@@ -981,21 +877,6 @@ class GitHubPlugin(BotCommander):
         response = requests.put('{}{}'.format(GITHUB_URL, api_part), data=json.dumps(data), headers=headers, timeout=10)
 
         if response.status_code != 204:
-            raise ValueError(response.status_code)
-
-    def add_user_to_org(self, user_id, real_org, role):
-        headers = {
-            'Authorization': 'token {}'.format(self.token),
-            'Accept': GITHUB_VERSION
-        }
-
-        data = {"role": role}
-
-        # Add the outside collab to the repo:
-        api_part = 'orgs/{}/memberships/{}'.format(real_org, user_id)
-        response = requests.put('{}{}'.format(GITHUB_URL, api_part), data=json.dumps(data), headers=headers, timeout=10)
-
-        if response.status_code != 200:
             raise ValueError(response.status_code)
 
     def create_new_repo(self, repo_to_create, org, visibility):


### PR DESCRIPTION
Hello,

I implemented Hubcommander for a customer of mine. We soon realised that some important commands are missing for us.

I have added these commands to the code and thought you guys probably like them too.

`!InviteUser`
A command that adds a GitHub user to your org. You can also set the permission level (admin or member)

`!AddUserToTeam`
A command that adds an existing user in your org to a specific team. If the user is not yet a part of your org, he will also get an invite. I had to update the existing `invite_user_to_gh_org_team` method to be able to also set a role here.

I am happy to get your feedback and commit any changes this might still need.

There will probably be coming some more updates by me in the futute. The customer really digs Hubcommander :)