### PR TITLE
Support Slack Ephemeral Messages

### DIFF
--- a/bot_components/slack_comm.py
+++ b/bot_components/slack_comm.py
@@ -14,28 +14,41 @@ from hubcommander import bot_components
 WORKING_COLOR = "#439FE0"
 
 
-def say(channel, attachments, text=None):
+def say(channel, attachments, text=None, ephemeral=False, ephemeral_user=None):
     """
     Sends a message (with attachments) to Slack. Use the send_* methods instead.
     :param channel:
     :param attachments:
-    :param raw:
+    :param text:
+    :param ephemeral: If True, then send send ephemeral message
+    :param ephemeral_user:ID of the user who will receive the ephemeral message
     :return:
     """
     if text is None:
-        bot_components.SLACK_CLIENT.api_call("chat.postMessage", channel=channel, text=" ",
-                                             attachments=json.dumps(attachments), as_user=True)
+        text=" "
+
+    if ephemeral:
+        bot_components.SLACK_CLIENT.api_call("chat.postEphemeral",
+                                             channel=channel, text=text,
+                                             user=ephemeral_user,
+                                             attachments=json.dumps(attachments),
+                                             as_user=True)
     else:
-        bot_components.SLACK_CLIENT.api_call("chat.postMessage", channel=channel, text=text,
-                                             attachments=json.dumps(attachments), as_user=True)
+        bot_components.SLACK_CLIENT.api_call("chat.postMessage",
+                                             channel=channel, text=text,
+                                             attachments=json.dumps(attachments),
+                                             as_user=True)
 
 
-def send_error(channel, text, markdown=False):
+def send_error(channel, text, markdown=False, ephemeral=False,
+               ephemeral_user=None):
     """
     Sends an "error" message to Slack.
     :param channel:
     :param text:
     :param markdown: If True, then look for markdown in the message.
+    :param ephemeral: True to send ephemeral mesaage
+    :param ephemeral_user:ID of the user who will receive the ephemeral message
     :return:
     """
     attachment = {
@@ -46,15 +59,19 @@ def send_error(channel, text, markdown=False):
     if markdown:
         attachment["mrkdwn_in"] = ["text"]
 
-    say(channel, [attachment])
+    say(channel, [attachment], ephemeral=ephemeral,
+        ephemeral_user=ephemeral_user)
 
 
-def send_info(channel, text, markdown=False):
+def send_info(channel, text, markdown=False, ephemeral=False,
+              ephemeral_user=None):
     """
     Sends an "info" message to Slack.
     :param channel:
     :param text:
     :param markdown: If True, then look for markdown in the message.
+    :param ephemeral: True to send ephemeral mesaage
+    :param ephemeral_user:ID of the user who will receive the ephemeral message
     :return:
     """
     attachment = {
@@ -65,16 +82,20 @@ def send_info(channel, text, markdown=False):
     if markdown:
         attachment["mrkdwn_in"] = ["text"]
 
-    say(channel, [attachment])
+    say(channel, [attachment], ephemeral=ephemeral,
+        ephemeral_user=ephemeral_user)
 
 
-def send_success(channel, text, markdown=False):
+def send_success(channel, text, markdown=False, ephemeral=False,
+                 ephemeral_user=None):
     """
     Sends an "success" message to Slack.
     :param channel:
     :param text:
     :param image: A choice of "awesome", "yougotit".
     :param markdown: If True, then look for markdown in the message.
+    :param ephemeral: True to send ephemeral mesaage
+    :param ephemeral_user:ID of the user who will receive the ephemeral message
     :return:
     """
     attachment = {
@@ -85,18 +106,21 @@ def send_success(channel, text, markdown=False):
     if markdown:
         attachment["mrkdwn_in"] = ["text"]
 
-    say(channel, [attachment])
+    say(channel, [attachment], ephemeral=ephemeral,
+        ephemeral_user=ephemeral_user)
 
 
-def send_raw(channel, text):
+def send_raw(channel, text, ephemeral=False, ephemeral_user=None):
     """
     Sends an "info" message to Slack.
     :param channel:
     :param text:
+    :param ephemeral: True to send ephemeral mesaage
+    :param ephemeral_user:ID of the user who will receive the ephemeral message
     :return:
     """
 
-    say(channel, None, text)
+    say(channel, None, text, ephemeral=ephemeral, ephemeral_user=ephemeral_user)
 
 
 def get_user_data(data):


### PR DESCRIPTION
Added support for ephemeral messages in below slack_comm functions 

say
send_*

#56 