### PR TITLE
Added multiple-domain DUO support

### DIFF
--- a/auth_plugins/duo/plugin.py
+++ b/auth_plugins/duo/plugin.py
@@ -30,20 +30,31 @@ class DuoPlugin(BotAuthPlugin):
     def __init__(self):
         super().__init__()
 
-        self.client = None
+        self.clients = {}
 
     def setup(self, secrets, **kwargs):
-        if not secrets.get("DUO_IKEY") or not secrets.get("DUO_SKEY") or not secrets.get("DUO_HOST"):
+        for variable, secret in secrets.items():
+            if "DUO_" in variable:
+                domain, host, ikey, skey = secret.split(",")
+                self.clients[domain] = Client(ikey, skey, host)
+
+        if not len(self.clients):
             raise NoSecretsProvidedError("Must provide secrets to enable authentication.")
 
-        self.client = Client(secrets["DUO_IKEY"], secrets["DUO_SKEY"], secrets["DUO_HOST"])
-
     def authenticate(self, data, user_data, **kwargs):
+        # Which domain does this user belong to?
+        domain = user_data["profile"]["email"].split("@")[1]
+        if not self.clients.get(domain):
+            send_error(data["channel"], "💀 @{}: Duo in this bot is not configured for the domain: `{}`. It needs "
+                                        "to be configured for you to run this command."
+                       .format(user_data["name"], domain), markdown=True, thread=data["ts"])
+            return False
+
         send_info(data["channel"], "🎟 @{}: Sending a Duo notification to your device. You must approve!"
                   .format(user_data["name"]), markdown=True, ephemeral_user=user_data["id"])
 
         try:
-            result = self._perform_auth(user_data)
+            result = self._perform_auth(user_data, self.clients[domain])
         except InvalidDuoResponseError as idre:
             send_error(data["channel"], "💀 @{}: There was a problem communicating with Duo. Got this status: {}. "
                                         "Aborting..."
@@ -71,14 +82,14 @@ class DuoPlugin(BotAuthPlugin):
                      .format(user_data["name"]), markdown=True, ephemeral_user=user_data["id"])
         return True
 
-    def _perform_auth(self, user_data):
+    def _perform_auth(self, user_data, client):
         # Push to devices:
         duo_params = {
             "username": user_data["profile"]["email"],
             "factor": "push",
             "device": "auto"
         }
-        response, data = self.client.api_call("POST", "/auth/v2/auth", duo_params)
+        response, data = client.api_call("POST", "/auth/v2/auth", duo_params)
         result = json.loads(data.decode("utf-8"))
 
         if response.status != 200:

--- a/decrypt_creds.py
+++ b/decrypt_creds.py
@@ -10,24 +10,33 @@ def get_credentials():
     # For Docker, encryption is assumed to be happening outside of this, and the secrets
     # are instead being passed in as environment variables:
     import os
-    return {
+
+    creds = {
         # Minimum
         "SLACK": os.environ["SLACK_TOKEN"],
 
         # Optional:
         "GITHUB": os.environ.get("GITHUB_TOKEN"),
-        "TRAVIS_PRO_USER": os.environ.get("TRAVIS_PRO_USER"),
-        "TRAVIS_PRO_ID": os.environ.get("TRAVIS_PRO_ID"),
-        "TRAVIS_PRO_TOKEN": os.environ.get("TRAVIS_PRO_TOKEN"),
-        "TRAVIS_PUBLIC_USER": os.environ.get("TRAVIS_PUBLIC_USER"),
-        "TRAVIS_PUBLIC_ID": os.environ.get("TRAVIS_PUBLIC_ID"),
-        "TRAVIS_PUBLIC_TOKEN": os.environ.get("TRAVIS_PUBLIC_TOKEN"),
-        "DUO_HOST": os.environ.get("DUO_HOST"),
-        "DUO_IKEY": os.environ.get("DUO_IKEY"),
-        "DUO_SKEY": os.environ.get("DUO_SKEY"),
+
+        # These are named the same as the env var, but these are the env vars should you
+        # want to leverage the feature:
+        # "TRAVIS_PRO_USER": os.environ.get("TRAVIS_PRO_USER"),
+        # "TRAVIS_PRO_ID": os.environ.get("TRAVIS_PRO_ID"),
+        # "TRAVIS_PRO_TOKEN": os.environ.get("TRAVIS_PRO_TOKEN"),
+        # "TRAVIS_PUBLIC_USER": os.environ.get("TRAVIS_PUBLIC_USER"),
+        # "TRAVIS_PUBLIC_ID": os.environ.get("TRAVIS_PUBLIC_ID"),
+        # "TRAVIS_PUBLIC_TOKEN": os.environ.get("TRAVIS_PUBLIC_TOKEN"),
+
+        # DUO_...NAME_OF_DUO_CRED: "domain-that-is-duod.com,duo_host,duo_ikey,duo_skey"
 
         # ADD MORE HERE...
     }
+
+    # Just adds the rest for freely-named ones (Like for Duo):
+    for variable, value in os.environ.items():
+        creds[variable] = value
+
+    return creds
 
 
 # def kms_decrypt():
@@ -69,9 +78,7 @@ secrets_to_encrypt = {
     "TRAVIS_PUBLIC_USER": "GitHub ID of GitHub account with access to Travis Public",
     "TRAVIS_PUBLIC_ID": "The ID of the Travis user. Use the Travis API to get this (for Public)",
     "TRAVIS_PUBLIC_TOKEN": Use the Travis API to get the Travis token (for the Travis Public account)",
-    "DUO-HOST": "xxxxxxxx.duosecurity.com",
-    "DUO-IKEY": "The IKEY for Duo",
-    "DUO-SKEY": "The SKEY for Duo"
+    "DUO_YOUR_DOMAIN": "your-domain-here.com,xxxxxxxx.duosecurity.com,THEDUOIKEY,THEDUOSKEY"
 }
 
 encrypt_res = kms_client.encrypt(KeyId=kms_arn, Plaintext=bytes(json.dumps(secrets_to_encrypt, indent=4), "utf-8"))

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -25,10 +25,19 @@ An example for how this is configured can be found in
 Enabling Duo
 ------------
 Duo is disabled by default. To enable Duo, you will need the following information:
+   1. The domain name that is Duo protected
+   1. The Duo Host
+   1. The "IKEY"
+   1. The "SKEY"
 
-   - `DUO-HOST`: Your administrator needs to provide you with this
-   - `DUO-IKEY`: The `IKEY`, provided to you by your administrator
-   - `DUO-SKEY`: The `SKEY`, provided to you by your administrator
+HubCommander supports multiple Duo domains. For this to work, you will need the information above
+for the given domain. Additionally, the secrets dictionary needs to be updated such that it has a key that starts
+with `DUO_`.  This key needs a comma-separated list of the domain, duo host, `ikey`, and `skey`.  It needs to look like:
+
+    "DUO_DOMAIN_ONE": "domainone.com,YOURHOST.duosecurity.com,THEIKEY,THESKEY"
+    "DUO_DOMAIN_TWO": "domaintwo.com,YOUROTHERHOST.duosecurity.com,THEOTHERIKEY,THEOTHERSKEY"
+
+The email address of the Slack user will determine which domain gets used.
 
 With the above information, you need to modify the secrets `dict` that is decrypted by the application
 on startup.

--- a/docs/command_config.md
+++ b/docs/command_config.md
@@ -44,3 +44,12 @@ By default, authentication is disabled. An example of enabling authentication ca
 [`config.py`](https://github.com/Netflix/hubcommander/blob/master/github/config.py) file.
 
 _For more details on authentication plugins, please read the [authentication plugin documentation](authentication.md)._
+
+
+### Hidden Commands
+
+If you ever retire a command, you can make it hidden from the `!Help` output. You can modify the command so that it
+outputs information redirecting the user to the new and supported command to utilize.
+
+To do this, in the command configuration, simply remove the `help` text. This command can stil be
+executed, but won't appear as a command.

--- a/hubcommander.py
+++ b/hubcommander.py
@@ -108,7 +108,12 @@ def setup(slackclient):
             if cmd["enabled"]:
                 print("\t[+] Adding command: \'{cmd}\'".format(cmd=cmd["command"]))
                 COMMANDS[cmd["command"].lower()] = cmd
-                HELP_TEXT.append("`{cmd}` - {help}\n".format(cmd=cmd["command"], help=cmd["help"]))
+
+                # Hidden commands: don't show on the help:
+                if cmd.get("help"):
+                    HELP_TEXT.append("`{cmd}` - {help}\n".format(cmd=cmd["command"], help=cmd["help"]))
+                else:
+                    print("\t[!] Not adding help text for hidden command: {}".format(cmd["command"]))
             else:
                 print("\t[/] Skipping disabled command: \'{cmd}\'".format(cmd=cmd["command"]))
         print("[+] Successfully enabled command plugin \"{}\"".format(name))


### PR DESCRIPTION
- This will change how DUO environment variables are sent in. Please see the updated README.
- This also adds support for hidden commands where help text is not specified. This is useful for
  commands that you have retired. This is so if users type in the retired command, they still
  get some output that you can control -- indicating to them that the command is retired and
  that another command should be used instead -- while not showing up in the help text.

closes #77 