### PR TITLE
Update for proper exit status

### DIFF
--- a/build_docker.sh
+++ b/build_docker.sh
@@ -55,5 +55,12 @@ echo "[-->] Now building the Docker image..."
 # Build that Docker image...
 docker build  -t netflixoss/hubcommander:${BUILD_TAG} --rm=true . --build-arg RTM_VERSION=${RTM_VERSION}
 
+cmd_st="$?"
+if [ $cmd_st -gt 0 ]
+then
+  echo "Error building image. Exiting."
+  exit $cmd_st
+fi
+
 echo
 echo "DONE!"


### PR DESCRIPTION
Small change to include a non-zero exit status if the docker build command failed for any reason.