### PR TITLE
[GH-98] The 'sudo' tag is now deprecated in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: required
-
 language: python
 
 python:


### PR DESCRIPTION
https://changelog.travis-ci.com/the-container-based-build-environment-is-fully-deprecated-84517

sudo required is deprecated