### PR TITLE
Update build status location

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ administrative or `owner` privileges to your GitHub organization members.
 
 | Service   | Master | Develop |
 |:-----------:|:--------:|:---------:|
-|Travis CI|[![Build Status](https://travis-ci.org/Netflix/hubcommander.svg?branch=master)](https://travis-ci.org/Netflix/hubcommander)|[![Build Status](https://travis-ci.org/Netflix/hubcommander.svg?branch=develop)](https://travis-ci.org/Netflix/hubcommander)|
+|Travis CI|[![Build Status](https://travis-ci.com/Netflix/hubcommander.svg?branch=master)](https://travis-ci.com/Netflix/hubcommander)|[![Build Status](https://travis-ci.com/Netflix/hubcommander.svg?branch=develop)](https://travis-ci.com/Netflix/hubcommander)|
 
 
 How does it work?


### PR DESCRIPTION
This build has been migrated to travis-ci.com as per their [recommendation](https://mailchi.mp/3d439eeb1098/travis-ciorg-is-moving-to-travis-cicom).