### PR TITLE
Updating the Travis Plugin to use travis-ci.com by default

### DIFF
--- a/command_plugins/travis_ci/plugin.py
+++ b/command_plugins/travis_ci/plugin.py
@@ -119,7 +119,7 @@ class TravisPlugin(BotCommander):
 
     @hubcommander_command(
         name="!EnableTravis",
-        usage="!EnableTravis <OrgWithRepo> <Repo>",
+        usage="!EnableTravis <OrgWithRepo> <Repo> [--public=true]",
         description="This will enable Travis CI on a GitHub repository.",
         required=[
             dict(name="org", properties=dict(type=str, help="The organization that contains the repo."),
@@ -127,14 +127,16 @@ class TravisPlugin(BotCommander):
             dict(name="repo", properties=dict(type=str, help="The repository to enable Travis CI on."),
                  validation_func=extract_repo_name, validation_func_kwargs={})
         ],
-        optional=[]
+        optional=[dict(name="--public",
+                       properties=dict(type=str, help="When set to true - attempts to enable Travis CI using the public travis-ci.org"))]
     )
     @auth()
-    def enable_travis_command(self, data, user_data, org, repo):
+    def enable_travis_command(self, data, user_data, org, repo, public):
         """
         Enables Travis CI on a repository within the organization.
 
-        Command is as follows: !enabletravis <organization> <repo>
+        Command is as follows: !enabletravis <organization> <repo> [--public=true]
+        :param public:
         :param repo:
         :param org:
         :param user_data:
@@ -162,7 +164,7 @@ class TravisPlugin(BotCommander):
                        "@{}: I encountered a problem:\n\n{}".format(user_data["name"], e), thread=data["ts"])
             return
 
-        which = "pro" if repo_result["private"] else "public"
+        which = "public" if (public and public.lower() == 'true') else "pro"
 
         try:
             # Sync with Travis CI so that it knows about the repo:

--- a/docs/travis_ci.md
+++ b/docs/travis_ci.md
@@ -1,14 +1,13 @@
 Travis CI Plugin
 =================
 
-The [Travis CI](https://travis-ci.org/) plugin features an `!EnableTravis` command which will enable Travis CI 
+The [Travis CI](https://travis-ci.com/) plugin features an `!EnableTravis` command which will enable Travis CI 
 on a given repository. By default, this plugin is disabled.
 
-This plugin makes an assumption that you have Travis CI Public (for public repos) and 
-Professional (for private repos) enabled for your GitHub organizations.
+This plugin makes an assumption that you have Travis CI enabled for your GitHub organizations.
 
-This plugin will automatically detect which Travis CI (Public vs. Pro) to use based on the public/private 
-visibility of a given GitHub repository.
+Since Travis CI Public (travis-ci.org) [is moving](https://blog.travis-ci.com/2018-05-02-open-source-projects-on-travis-ci-com-with-github-apps) to Travis CI Pro (travis-ci.com), 
+the plugin will default to using Travis CI Pro.
 
 How does it work?
 ----------------
@@ -26,11 +25,9 @@ then run the API command to enable Travis CI on the repo.
 
 Configuration
 -------------
-This plugin requires access to the Travis CI API version 3 
-([currently in closed BETA](https://developer.travis-ci.org/)). You must contact Travis CI's support 
-and request a GitHub ID to be added into the beta for access to the methods utilized by this plugin. 
+This plugin requires access to [Travis CI API version 3](https://developer.travis-ci.com/). 
 
-Once you are added into the closed beta, you will need to get your Travis CI tokens. These tokens
+You will need to get your Travis CI tokens. These tokens
 are _different_ for public and professional Travis CI.
 
 ### GitHub API Token for Travis


### PR DESCRIPTION
Since Travis CI Public (travis-ci.org) [is moving](https://blog.travis-ci.com/2018-05-02-open-source-projects-on-travis-ci-com-with-github-apps) to Travis CI Pro (travis-ci.com),  the plugin should default to using Travis CI Pro. 
Added a new optional argument `—public`, that when set to `true`, attempts to enable Travis CI using travis-ci.org. 