### PR TITLE
update dependencies 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-  - "3.6"
+  - "3.8"
 
 install:
   - pip install -e .

--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,10 @@ with open(os.path.join(ROOT, "__about__.py")) as f:
 
 install_requires = [
     'boto3>=1.4.3',     # For KMS support
-    'duo_client==3.0',
+    'duo_client>=4.0',
     'tabulate>=0.7.7',
     'validators>=0.11.1',
-    'rtmbot==0.4.0'
+    'rtmbot>=0.4.0'
 ]
 
 tests_require = [


### PR DESCRIPTION
For rtmbot and duo_client to allow for newer versions. 

The duo_client update was necessary to allow this plugin to work on python > 3.7 (duo_client used the reserved keyword `async` in versions > 4.0)

It will also allow us to use newer versions of the rtmbot.