### PR TITLE
Exclude org employees from using addcollab

### DIFF
--- a/command_plugins/github/config.py
+++ b/command_plugins/github/config.py
@@ -14,6 +14,11 @@ ORGS = {
                 "name": "TeamName"      # The name of the team here...
             }
         ]
+        "collab_validation_teams": [
+            # If users are members of any of the teams in this list, they will
+            # not be added as outside collaborators
+            "TeamName"
+        ]
     }
 }
 


### PR DESCRIPTION
If an employee is already a member of an org, don't allow them to get set as an outside collaborator as well. 

This works by allowing you to set a list of teams per org in the config.py that we can check against for team membership. If a user tries to call addcollab for an org but is already a member of any of the listed teams for that org, then the bot will error. This is useful for preventing duplicate, conflicting roles for a user. 

It is also opt-in; if you don't set any teams in the new "collab_validation_teams" setting, then AddCollab will continue to work as it did before. 